### PR TITLE
Performance optimization: using NextBytesNoCopy where possible

### DIFF
--- a/data_eit.go
+++ b/data_eit.go
@@ -36,7 +36,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -45,7 +45,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	d.TransportStreamID = uint16(bs[0])<<8 | uint16(bs[1])
 
 	// Get next 2 bytes
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -75,7 +75,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	// Loop until end of section data is reached
 	for i.Offset() < offsetSectionsEnd {
 		// Get next 2 bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_eit.go
+++ b/data_eit.go
@@ -36,7 +36,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -45,7 +45,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	d.TransportStreamID = uint16(bs[0])<<8 | uint16(bs[1])
 
 	// Get next 2 bytes
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -75,7 +75,7 @@ func parseEITSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	// Loop until end of section data is reached
 	for i.Offset() < offsetSectionsEnd {
 		// Get next 2 bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_nit.go
+++ b/data_nit.go
@@ -35,7 +35,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -50,7 +50,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 		ts := &NITDataTransportStream{}
 
 		// Get next bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -59,7 +59,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 		ts.TransportStreamID = uint16(bs[0])<<8 | uint16(bs[1])
 
 		// Get next bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_nit.go
+++ b/data_nit.go
@@ -35,7 +35,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -50,7 +50,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 		ts := &NITDataTransportStream{}
 
 		// Get next bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -59,7 +59,7 @@ func parseNITSection(i *astikit.BytesIterator, tableIDExtension uint16) (d *NITD
 		ts.TransportStreamID = uint16(bs[0])<<8 | uint16(bs[1])
 
 		// Get next bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_pat.go
+++ b/data_pat.go
@@ -32,7 +32,7 @@ func parsePATSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	for i.Offset() < offsetSectionsEnd {
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytesFast(4); err != nil {
+		if bs, err = i.NextBytesNoCopy(4); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_pat.go
+++ b/data_pat.go
@@ -32,7 +32,7 @@ func parsePATSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 	for i.Offset() < offsetSectionsEnd {
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytes(4); err != nil {
+		if bs, err = i.NextBytesFast(4); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_pat_test.go
+++ b/data_pat_test.go
@@ -35,7 +35,7 @@ func TestParsePATSection(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWritePatSection(t *testing.T) {
+func TestWritePATSection(t *testing.T) {
 	bw := &bytes.Buffer{}
 	w := astikit.NewBitsWriter(astikit.BitsWriterOptions{Writer: bw})
 	n, err := writePATSection(w, pat)
@@ -43,4 +43,26 @@ func TestWritePatSection(t *testing.T) {
 	assert.Equal(t, n, 8)
 	assert.Equal(t, n, bw.Len())
 	assert.Equal(t, patBytes(), bw.Bytes())
+}
+
+func BenchmarkParsePATSection(b *testing.B) {
+	b.ReportAllocs()
+	bs := patBytes()
+
+	for i := 0; i < b.N; i++ {
+		parsePATSection(astikit.NewBytesIterator(bs), len(bs), uint16(1))
+	}
+}
+
+func BenchmarkWritePATSection(b *testing.B) {
+	b.ReportAllocs()
+
+	bw := &bytes.Buffer{}
+	bw.Grow(1024)
+	w := astikit.NewBitsWriter(astikit.BitsWriterOptions{Writer: bw})
+
+	for i := 0; i < b.N; i++ {
+		bw.Reset()
+		writePATSection(w, pat)
+	}
 }

--- a/data_pes.go
+++ b/data_pes.go
@@ -162,7 +162,7 @@ func parsePESHeader(i *astikit.BytesIterator) (h *PESHeader, dataStart, dataEnd 
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -276,7 +276,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 	// ES rate
 	if h.HasESRate {
 		var bs []byte
-		if bs, err = i.NextBytesFast(3); err != nil {
+		if bs, err = i.NextBytesNoCopy(3); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -304,7 +304,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 	// CRC
 	if h.HasCRC {
 		var bs []byte
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -347,7 +347,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 		// Program packet sequence counter
 		if h.HasProgramPacketSequenceCounter {
 			var bs []byte
-			if bs, err = i.NextBytesFast(2); err != nil {
+			if bs, err = i.NextBytesNoCopy(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -359,7 +359,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 		// P-STD buffer
 		if h.HasPSTDBuffer {
 			var bs []byte
-			if bs, err = i.NextBytesFast(2); err != nil {
+			if bs, err = i.NextBytesNoCopy(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -405,7 +405,7 @@ func parseDSMTrickMode(i byte) (m *DSMTrickMode) {
 // parsePTSOrDTS parses a PTS or a DTS
 func parsePTSOrDTS(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(5); err != nil {
+	if bs, err = i.NextBytesNoCopy(5); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -416,7 +416,7 @@ func parsePTSOrDTS(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 // parseESCR parses an ESCR
 func parseESCR(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(6); err != nil {
+	if bs, err = i.NextBytesNoCopy(6); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/data_pes.go
+++ b/data_pes.go
@@ -162,7 +162,7 @@ func parsePESHeader(i *astikit.BytesIterator) (h *PESHeader, dataStart, dataEnd 
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -276,7 +276,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 	// ES rate
 	if h.HasESRate {
 		var bs []byte
-		if bs, err = i.NextBytes(3); err != nil {
+		if bs, err = i.NextBytesFast(3); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -304,7 +304,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 	// CRC
 	if h.HasCRC {
 		var bs []byte
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -347,7 +347,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 		// Program packet sequence counter
 		if h.HasProgramPacketSequenceCounter {
 			var bs []byte
-			if bs, err = i.NextBytes(2); err != nil {
+			if bs, err = i.NextBytesFast(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -359,7 +359,7 @@ func parsePESOptionalHeader(i *astikit.BytesIterator) (h *PESOptionalHeader, dat
 		// P-STD buffer
 		if h.HasPSTDBuffer {
 			var bs []byte
-			if bs, err = i.NextBytes(2); err != nil {
+			if bs, err = i.NextBytesFast(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -405,7 +405,7 @@ func parseDSMTrickMode(i byte) (m *DSMTrickMode) {
 // parsePTSOrDTS parses a PTS or a DTS
 func parsePTSOrDTS(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(5); err != nil {
+	if bs, err = i.NextBytesFast(5); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -416,7 +416,7 @@ func parsePTSOrDTS(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 // parseESCR parses an ESCR
 func parseESCR(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(6); err != nil {
+	if bs, err = i.NextBytesFast(6); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/data_pes_test.go
+++ b/data_pes_test.go
@@ -485,3 +485,25 @@ func TestWritePESOptionalHeader(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkParsePESData(b *testing.B) {
+	bss := make([][]byte, len(pesTestCases))
+
+	for ti, tc := range pesTestCases {
+		buf := bytes.Buffer{}
+		w := astikit.NewBitsWriter(astikit.BitsWriterOptions{Writer: &buf})
+		tc.headerBytesFunc(w, true, true)
+		tc.optionalHeaderBytesFunc(w, true, true)
+		tc.bytesFunc(w, true, true)
+		bss[ti] = buf.Bytes()
+	}
+
+	for ti, tc := range pesTestCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				parsePESData(astikit.NewBytesIterator(bss[ti]))
+			}
+		})
+	}
+}

--- a/data_pmt.go
+++ b/data_pmt.go
@@ -58,7 +58,7 @@ func parsePMTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -88,7 +88,7 @@ func parsePMTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 		e.StreamType = StreamType(b)
 
 		// Get next bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_pmt.go
+++ b/data_pmt.go
@@ -58,7 +58,7 @@ func parsePMTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -88,7 +88,7 @@ func parsePMTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 		e.StreamType = StreamType(b)
 
 		// Get next bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_pmt_test.go
+++ b/data_pmt_test.go
@@ -49,3 +49,25 @@ func TestWritePMTSection(t *testing.T) {
 	assert.Equal(t, n, buf.Len())
 	assert.Equal(t, pmtBytes(), buf.Bytes())
 }
+
+func BenchmarkParsePMTSection(b *testing.B) {
+	b.ReportAllocs()
+	bs := pmtBytes()
+
+	for i := 0; i < b.N; i++ {
+		parsePMTSection(astikit.NewBytesIterator(bs), len(bs), uint16(1))
+	}
+}
+
+func BenchmarkWritePMTSection(b *testing.B) {
+	b.ReportAllocs()
+
+	bw := &bytes.Buffer{}
+	bw.Grow(1024)
+	w := astikit.NewBitsWriter(astikit.BitsWriterOptions{Writer: bw})
+
+	for i := 0; i < b.N; i++ {
+		bw.Reset()
+		writePMTSection(w, pmt)
+	}
+}

--- a/data_psi.go
+++ b/data_psi.go
@@ -165,7 +165,7 @@ func parsePSISection(i *astikit.BytesIterator) (s *PSISection, stop bool, err er
 			// Get CRC32 data
 			i.Seek(offsetStart)
 			var crc32Data []byte
-			if crc32Data, err = i.NextBytes(offsetSectionsEnd - offsetStart); err != nil {
+			if crc32Data, err = i.NextBytesFast(offsetSectionsEnd - offsetStart); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -189,7 +189,7 @@ func parsePSISection(i *astikit.BytesIterator) (s *PSISection, stop bool, err er
 // parseCRC32 parses a CRC32
 func parseCRC32(i *astikit.BytesIterator) (c uint32, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(4); err != nil {
+	if bs, err = i.NextBytesFast(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -229,7 +229,7 @@ func parsePSISectionHeader(i *astikit.BytesIterator) (h *PSISectionHeader, offse
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -358,7 +358,7 @@ func parsePSISectionSyntaxHeader(i *astikit.BytesIterator) (h *PSISectionSyntaxH
 
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/data_psi.go
+++ b/data_psi.go
@@ -165,7 +165,7 @@ func parsePSISection(i *astikit.BytesIterator) (s *PSISection, stop bool, err er
 			// Get CRC32 data
 			i.Seek(offsetStart)
 			var crc32Data []byte
-			if crc32Data, err = i.NextBytesFast(offsetSectionsEnd - offsetStart); err != nil {
+			if crc32Data, err = i.NextBytesNoCopy(offsetSectionsEnd - offsetStart); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}
@@ -189,7 +189,7 @@ func parsePSISection(i *astikit.BytesIterator) (s *PSISection, stop bool, err er
 // parseCRC32 parses a CRC32
 func parseCRC32(i *astikit.BytesIterator) (c uint32, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(4); err != nil {
+	if bs, err = i.NextBytesNoCopy(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -229,7 +229,7 @@ func parsePSISectionHeader(i *astikit.BytesIterator) (h *PSISectionHeader, offse
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -358,7 +358,7 @@ func parsePSISectionSyntaxHeader(i *astikit.BytesIterator) (h *PSISectionSyntaxH
 
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/data_psi_test.go
+++ b/data_psi_test.go
@@ -374,3 +374,10 @@ func TestWritePSIData(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkParsePSIData(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parsePSIData(astikit.NewBytesIterator(psiBytes()))
+	}
+}

--- a/data_sdt.go
+++ b/data_sdt.go
@@ -42,7 +42,7 @@ func parseSDTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -59,7 +59,7 @@ func parseSDTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 		s := &SDTDataService{}
 
 		// Get next bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/data_sdt.go
+++ b/data_sdt.go
@@ -42,7 +42,7 @@ func parseSDTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -59,7 +59,7 @@ func parseSDTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 		s := &SDTDataService{}
 
 		// Get next bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}

--- a/descriptor.go
+++ b/descriptor.go
@@ -340,7 +340,7 @@ func newDescriptorContent(i *astikit.BytesIterator, offsetEnd int) (d *Descripto
 	for i.Offset() < offsetEnd {
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -793,7 +793,7 @@ type DescriptorMaximumBitrate struct {
 func newDescriptorMaximumBitrate(i *astikit.BytesIterator) (d *DescriptorMaximumBitrate, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(3); err != nil {
+	if bs, err = i.NextBytesNoCopy(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -873,7 +873,7 @@ type DescriptorPrivateDataIndicator struct {
 func newDescriptorPrivateDataIndicator(i *astikit.BytesIterator) (d *DescriptorPrivateDataIndicator, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(4); err != nil {
+	if bs, err = i.NextBytesNoCopy(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -891,7 +891,7 @@ type DescriptorPrivateDataSpecifier struct {
 func newDescriptorPrivateDataSpecifier(i *astikit.BytesIterator) (d *DescriptorPrivateDataSpecifier, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(4); err != nil {
+	if bs, err = i.NextBytesNoCopy(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -911,7 +911,7 @@ type DescriptorRegistration struct {
 func newDescriptorRegistration(i *astikit.BytesIterator, offsetEnd int) (d *DescriptorRegistration, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(4); err != nil {
+	if bs, err = i.NextBytesNoCopy(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -1089,7 +1089,7 @@ func newDescriptorSubtitling(i *astikit.BytesIterator, offsetEnd int) (d *Descri
 
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -1098,7 +1098,7 @@ func newDescriptorSubtitling(i *astikit.BytesIterator, offsetEnd int) (d *Descri
 		itm.CompositionPageID = uint16(bs[0])<<8 | uint16(bs[1])
 
 		// Get next bytes
-		if bs, err = i.NextBytesFast(2); err != nil {
+		if bs, err = i.NextBytesNoCopy(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -1268,7 +1268,7 @@ func newDescriptorVBIData(i *astikit.BytesIterator, offsetEnd int) (d *Descripto
 func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -1281,7 +1281,7 @@ func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 		offsetEnd := i.Offset() + length
 		for i.Offset() < offsetEnd {
 			// Get next 2 bytes
-			if bs, err = i.NextBytesFast(2); err != nil {
+			if bs, err = i.NextBytesNoCopy(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}

--- a/descriptor.go
+++ b/descriptor.go
@@ -340,7 +340,7 @@ func newDescriptorContent(i *astikit.BytesIterator, offsetEnd int) (d *Descripto
 	for i.Offset() < offsetEnd {
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -793,7 +793,7 @@ type DescriptorMaximumBitrate struct {
 func newDescriptorMaximumBitrate(i *astikit.BytesIterator) (d *DescriptorMaximumBitrate, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(3); err != nil {
+	if bs, err = i.NextBytesFast(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -873,7 +873,7 @@ type DescriptorPrivateDataIndicator struct {
 func newDescriptorPrivateDataIndicator(i *astikit.BytesIterator) (d *DescriptorPrivateDataIndicator, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(4); err != nil {
+	if bs, err = i.NextBytesFast(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -891,7 +891,7 @@ type DescriptorPrivateDataSpecifier struct {
 func newDescriptorPrivateDataSpecifier(i *astikit.BytesIterator) (d *DescriptorPrivateDataSpecifier, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(4); err != nil {
+	if bs, err = i.NextBytesFast(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -911,7 +911,7 @@ type DescriptorRegistration struct {
 func newDescriptorRegistration(i *astikit.BytesIterator, offsetEnd int) (d *DescriptorRegistration, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(4); err != nil {
+	if bs, err = i.NextBytesFast(4); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -1089,7 +1089,7 @@ func newDescriptorSubtitling(i *astikit.BytesIterator, offsetEnd int) (d *Descri
 
 		// Get next bytes
 		var bs []byte
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -1098,7 +1098,7 @@ func newDescriptorSubtitling(i *astikit.BytesIterator, offsetEnd int) (d *Descri
 		itm.CompositionPageID = uint16(bs[0])<<8 | uint16(bs[1])
 
 		// Get next bytes
-		if bs, err = i.NextBytes(2); err != nil {
+		if bs, err = i.NextBytesFast(2); err != nil {
 			err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 			return
 		}
@@ -1268,7 +1268,7 @@ func newDescriptorVBIData(i *astikit.BytesIterator, offsetEnd int) (d *Descripto
 func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -1281,7 +1281,7 @@ func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 		offsetEnd := i.Offset() + length
 		for i.Offset() < offsetEnd {
 			// Get next 2 bytes
-			if bs, err = i.NextBytes(2); err != nil {
+			if bs, err = i.NextBytesFast(2); err != nil {
 				err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 				return
 			}

--- a/dvb.go
+++ b/dvb.go
@@ -17,7 +17,7 @@ import (
 func parseDVBTime(i *astikit.BytesIterator) (t time.Time, err error) {
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -49,7 +49,7 @@ func parseDVBTime(i *astikit.BytesIterator) (t time.Time, err error) {
 // 16 bit field containing the duration of the event in hours, minutes. format: 4 digits, 4 - bit BCD = 18 bit
 func parseDVBDurationMinutes(i *astikit.BytesIterator) (d time.Duration, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(2); err != nil {
+	if bs, err = i.NextBytesFast(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -61,7 +61,7 @@ func parseDVBDurationMinutes(i *astikit.BytesIterator) (d time.Duration, err err
 // 24 bit field containing the duration of the event in hours, minutes, seconds. format: 6 digits, 4 - bit BCD = 24 bit
 func parseDVBDurationSeconds(i *astikit.BytesIterator) (d time.Duration, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(3); err != nil {
+	if bs, err = i.NextBytesFast(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/dvb.go
+++ b/dvb.go
@@ -17,7 +17,7 @@ import (
 func parseDVBTime(i *astikit.BytesIterator) (t time.Time, err error) {
 	// Get next 2 bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -49,7 +49,7 @@ func parseDVBTime(i *astikit.BytesIterator) (t time.Time, err error) {
 // 16 bit field containing the duration of the event in hours, minutes. format: 4 digits, 4 - bit BCD = 18 bit
 func parseDVBDurationMinutes(i *astikit.BytesIterator) (d time.Duration, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(2); err != nil {
+	if bs, err = i.NextBytesNoCopy(2); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -61,7 +61,7 @@ func parseDVBDurationMinutes(i *astikit.BytesIterator) (d time.Duration, err err
 // 24 bit field containing the duration of the event in hours, minutes, seconds. format: 6 digits, 4 - bit BCD = 24 bit
 func parseDVBDurationSeconds(i *astikit.BytesIterator) (d time.Duration, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(3); err != nil {
+	if bs, err = i.NextBytesNoCopy(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/asticode/go-astits
 go 1.13
 
 require (
-	github.com/asticode/go-astikit v0.19.0
+	github.com/asticode/go-astikit v0.20.0
 	github.com/pkg/profile v1.4.0
 	github.com/stretchr/testify v1.4.0
 )
-
-replace github.com/asticode/go-astikit v0.19.0 => github.com/barbashov/go-astikit v0.19.1

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pkg/profile v1.4.0
 	github.com/stretchr/testify v1.4.0
 )
+
+replace github.com/asticode/go-astikit v0.19.0 => github.com/barbashov/go-astikit v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/asticode/go-astikit v0.19.0 h1:NEeyjodbwGTZN7Pn8IYXFw1Occl59okjg6wYfDce7uM=
-github.com/asticode/go-astikit v0.19.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
+github.com/barbashov/go-astikit v0.19.1 h1:T5lNdL0DHPJIqA01X0KFKEsuNYG5IkW/4ZTA4DzfHuA=
+github.com/barbashov/go-astikit v0.19.1/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/profile v1.4.0 h1:uCmaf4vVbWAOZz36k1hrQD7ijGRzLwaME8Am/7a4jZI=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/barbashov/go-astikit v0.19.1 h1:T5lNdL0DHPJIqA01X0KFKEsuNYG5IkW/4ZTA4DzfHuA=
-github.com/barbashov/go-astikit v0.19.1/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
+github.com/asticode/go-astikit v0.20.0 h1:+7N+J4E4lWx2QOkRdOf6DafWJMv6O4RRfgClwQokrH8=
+github.com/asticode/go-astikit v0.20.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/profile v1.4.0 h1:uCmaf4vVbWAOZz36k1hrQD7ijGRzLwaME8Am/7a4jZI=

--- a/packet.go
+++ b/packet.go
@@ -130,7 +130,7 @@ func payloadOffset(offsetStart int, h *PacketHeader, a *PacketAdaptationField) (
 func parsePacketHeader(i *astikit.BytesIterator) (h *PacketHeader, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytesFast(3); err != nil {
+	if bs, err = i.NextBytesNoCopy(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -255,7 +255,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 				// Legal time window
 				if a.AdaptationExtensionField.HasLegalTimeWindow {
 					var bs []byte
-					if bs, err = i.NextBytesFast(2); err != nil {
+					if bs, err = i.NextBytesNoCopy(2); err != nil {
 						err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 						return
 					}
@@ -266,7 +266,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 				// Piecewise rate
 				if a.AdaptationExtensionField.HasPiecewiseRate {
 					var bs []byte
-					if bs, err = i.NextBytesFast(3); err != nil {
+					if bs, err = i.NextBytesNoCopy(3); err != nil {
 						err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 						return
 					}
@@ -306,7 +306,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 // Program clock reference, stored as 33 bits base, 6 bits reserved, 9 bits extension.
 func parsePCR(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytesFast(6); err != nil {
+	if bs, err = i.NextBytesNoCopy(6); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/packet.go
+++ b/packet.go
@@ -130,7 +130,7 @@ func payloadOffset(offsetStart int, h *PacketHeader, a *PacketAdaptationField) (
 func parsePacketHeader(i *astikit.BytesIterator) (h *PacketHeader, err error) {
 	// Get next bytes
 	var bs []byte
-	if bs, err = i.NextBytes(3); err != nil {
+	if bs, err = i.NextBytesFast(3); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}
@@ -255,7 +255,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 				// Legal time window
 				if a.AdaptationExtensionField.HasLegalTimeWindow {
 					var bs []byte
-					if bs, err = i.NextBytes(2); err != nil {
+					if bs, err = i.NextBytesFast(2); err != nil {
 						err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 						return
 					}
@@ -266,7 +266,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 				// Piecewise rate
 				if a.AdaptationExtensionField.HasPiecewiseRate {
 					var bs []byte
-					if bs, err = i.NextBytes(3); err != nil {
+					if bs, err = i.NextBytesFast(3); err != nil {
 						err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 						return
 					}
@@ -306,7 +306,7 @@ func parsePacketAdaptationField(i *astikit.BytesIterator) (a *PacketAdaptationFi
 // Program clock reference, stored as 33 bits base, 6 bits reserved, 9 bits extension.
 func parsePCR(i *astikit.BytesIterator) (cr *ClockReference, err error) {
 	var bs []byte
-	if bs, err = i.NextBytes(6); err != nil {
+	if bs, err = i.NextBytesFast(6); err != nil {
 		err = fmt.Errorf("astits: fetching next bytes failed: %w", err)
 		return
 	}

--- a/packet_test.go
+++ b/packet_test.go
@@ -252,3 +252,12 @@ func BenchmarkWritePCR(b *testing.B) {
 		writePCR(w, pcr)
 	}
 }
+
+func BenchmarkParsePacket(b *testing.B) {
+	bs, _ := packet(*packetHeader, *packetAdaptationField, []byte("payload"), true)
+
+	for i := 0; i < b.N; i++ {
+		b.ReportAllocs()
+		parsePacket(astikit.NewBytesIterator(bs))
+	}
+}


### PR DESCRIPTION
(For this to merge, https://github.com/asticode/go-astikit/pull/9 should be merged before.)

I've changed a bunch of places in demuxer to use NextByteNoCopy instead of NextByte.
I can't say it's night and day difference, but still it's a nice little improvement :)
Benchmark results follow.

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astits
BenchmarkParsePATSection-8   	12254799	        97.23 ns/op	      72 B/op	       7 allocs/op
BenchmarkParsePESData
BenchmarkParsePESData/without_header-8         	17240697	        69.27 ns/op	      56 B/op	       4 allocs/op
BenchmarkParsePESData/with_header-8            	 4049978	       295.6 ns/op	     304 B/op	      18 allocs/op
BenchmarkParsePMTSection-8                     	 4220971	       282.7 ns/op	     632 B/op	      15 allocs/op
BenchmarkParsePSIData-8                        	  141775	      8532 ns/op	    5321 B/op	     169 allocs/op
BenchmarkParseDescriptor
BenchmarkParseDescriptor/AC3-8                                	 8806401	       136.0 ns/op	     288 B/op	       6 allocs/op
BenchmarkParseDescriptor/ISO639LanguageAndAudioType-8         	 9917152	       121.1 ns/op	     288 B/op	       6 allocs/op
BenchmarkParseDescriptor/MaximumBitrate-8                     	10645449	       113.2 ns/op	     260 B/op	       6 allocs/op
BenchmarkParseDescriptor/NetworkName-8                        	 9511978	       126.6 ns/op	     280 B/op	       6 allocs/op
BenchmarkParseDescriptor/Service-8                            	 8413123	       141.9 ns/op	     336 B/op	       7 allocs/op
BenchmarkParseDescriptor/ShortEvent-8                         	 7699062	       156.6 ns/op	     344 B/op	       8 allocs/op
BenchmarkParseDescriptor/StreamIdentifier-8                   	11814889	       101.9 ns/op	     254 B/op	       5 allocs/op
BenchmarkParseDescriptor/Subtitling-8                         	 4409683	       271.7 ns/op	     412 B/op	      15 allocs/op
BenchmarkParseDescriptor/Teletext-8                           	 5119393	       234.3 ns/op	     370 B/op	      11 allocs/op
BenchmarkParseDescriptor/ExtendedEvent-8                      	 5383294	       222.2 ns/op	     416 B/op	      11 allocs/op
BenchmarkParseDescriptor/EnhancedAC3-8                        	 8112375	       147.8 ns/op	     304 B/op	       6 allocs/op
BenchmarkParseDescriptor/Extension-8                          	 6975066	       171.7 ns/op	     352 B/op	       8 allocs/op
BenchmarkParseDescriptor/Component-8                          	 8063560	       148.5 ns/op	     324 B/op	       7 allocs/op
BenchmarkParseDescriptor/Content-8                            	 7474143	       161.0 ns/op	     290 B/op	       8 allocs/op
BenchmarkParseDescriptor/ParentalRating-8                     	 7275045	       164.7 ns/op	     320 B/op	       8 allocs/op
BenchmarkParseDescriptor/LocalTimeOffset-8                    	 2556608	       468.0 ns/op	     392 B/op	      13 allocs/op
BenchmarkParseDescriptor/VBIData-8                            	 6399276	       187.6 ns/op	     326 B/op	       9 allocs/op
BenchmarkParseDescriptor/VBITeletext-8                        	 7012162	       170.5 ns/op	     320 B/op	       8 allocs/op
BenchmarkParseDescriptor/AVCVideo-8                           	10797754	       111.3 ns/op	     264 B/op	       5 allocs/op
BenchmarkParseDescriptor/PrivateDataSpecifier-8               	10777999	       112.2 ns/op	     260 B/op	       6 allocs/op
BenchmarkParseDescriptor/DataStreamAlignment-8                	11817196	       101.8 ns/op	     254 B/op	       5 allocs/op
BenchmarkParseDescriptor/PrivateDataIndicator-8               	10707218	       112.0 ns/op	     260 B/op	       6 allocs/op
BenchmarkParseDescriptor/UserDefined-8                        	12038341	       100.3 ns/op	     256 B/op	       5 allocs/op
BenchmarkParseDescriptor/Registration-8                       	 8706368	       137.6 ns/op	     292 B/op	       7 allocs/op
BenchmarkParseDescriptor/Unknown-8                            	 9858508	       121.5 ns/op	     288 B/op	       6 allocs/op
BenchmarkParseDescriptor/Extension#01-8                       	 8554720	       140.0 ns/op	     304 B/op	       7 allocs/op
BenchmarkParsePacket-8                                        	 4242537	       281.3 ns/op	     448 B/op	      15 allocs/op
BenchmarkDemuxer_NextData-8   	     	     	     	     	  179368	        6088 ns/op	    6410 B/op	     188 allocs/op
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astits
BenchmarkParsePATSection-8      14293448            83.59 ns/op       64 B/op          5 allocs/op
BenchmarkParsePESData
BenchmarkParsePESData/without_header-8          20300631            58.82 ns/op       52 B/op          3 allocs/op
BenchmarkParsePESData/with_header-8              5215488           229.1 ns/op       280 B/op         10 allocs/op
BenchmarkParsePMTSection-8                       5153559           232.2 ns/op       618 B/op          9 allocs/op
BenchmarkParsePSIData-8                           150284          7986 ns/op        5049 B/op        115 allocs/op
BenchmarkParseDescriptor
BenchmarkParseDescriptor/AC3-8                                   9969420           119.7 ns/op       284 B/op          4 allocs/op
BenchmarkParseDescriptor/ISO639LanguageAndAudioType-8           11080315           108.2 ns/op       284 B/op          4 allocs/op
BenchmarkParseDescriptor/MaximumBitrate-8                       14564409            82.07 ns/op      252 B/op          3 allocs/op
BenchmarkParseDescriptor/NetworkName-8                          11150904           108.1 ns/op       276 B/op          4 allocs/op
BenchmarkParseDescriptor/Service-8                               9185078           130.7 ns/op       328 B/op          5 allocs/op
BenchmarkParseDescriptor/ShortEvent-8                            8483942           141.8 ns/op       344 B/op          6 allocs/op
BenchmarkParseDescriptor/StreamIdentifier-8                     15024884            79.83 ns/op      249 B/op          3 allocs/op
BenchmarkParseDescriptor/Subtitling-8                            5325788           226.1 ns/op       398 B/op          9 allocs/op
BenchmarkParseDescriptor/Teletext-8                              5553873           215.2 ns/op       366 B/op          9 allocs/op
BenchmarkParseDescriptor/ExtendedEvent-8                         5627692           209.0 ns/op       416 B/op          9 allocs/op
BenchmarkParseDescriptor/EnhancedAC3-8                           9031544           132.8 ns/op       300 B/op          4 allocs/op
BenchmarkParseDescriptor/Extension-8                             7636591           157.5 ns/op       352 B/op          6 allocs/op
BenchmarkParseDescriptor/Component-8                             9726552           123.7 ns/op       320 B/op          5 allocs/op
BenchmarkParseDescriptor/Content-8                               9240913           129.0 ns/op       283 B/op          5 allocs/op
BenchmarkParseDescriptor/ParentalRating-8                        8024780           150.0 ns/op       316 B/op          6 allocs/op
BenchmarkParseDescriptor/LocalTimeOffset-8                       2829170           424.7 ns/op       376 B/op          7 allocs/op
BenchmarkParseDescriptor/VBIData-8                               6965751           172.3 ns/op       322 B/op          7 allocs/op
BenchmarkParseDescriptor/VBITeletext-8                           7676050           156.5 ns/op       315 B/op          6 allocs/op
BenchmarkParseDescriptor/AVCVideo-8                             13757174            87.12 ns/op      256 B/op          3 allocs/op
BenchmarkParseDescriptor/PrivateDataSpecifier-8                 14734185            82.31 ns/op      252 B/op          3 allocs/op
BenchmarkParseDescriptor/DataStreamAlignment-8                  14950507            80.34 ns/op      249 B/op          3 allocs/op
BenchmarkParseDescriptor/PrivateDataIndicator-8                 14538712            82.22 ns/op      252 B/op          3 allocs/op
BenchmarkParseDescriptor/UserDefined-8                          14633461            82.71 ns/op      252 B/op          3 allocs/op
BenchmarkParseDescriptor/Registration-8                         11132430           108.7 ns/op       284 B/op          4 allocs/op
BenchmarkParseDescriptor/Unknown-8                              11541582           104.9 ns/op       284 B/op          4 allocs/op
BenchmarkParseDescriptor/Extension#01-8                          9737190           123.8 ns/op       300 B/op          5 allocs/op
BenchmarkParsePacket-8                                           5243634           229.4 ns/op       416 B/op          9 allocs/op
BenchmarkDemuxer_NextData-8   	     	     	     	     	  206743	        5514 ns/op	    6082 B/op	     122 allocs/op
```