### PR TITLE
packetPool: ignore TEI and let the caller decide what to do

### DIFF
--- a/packet_pool.go
+++ b/packet_pool.go
@@ -21,11 +21,6 @@ func newPacketPool() *packetPool {
 
 // add adds a new packet to the pool
 func (b *packetPool) add(p *Packet) (ps []*Packet) {
-	// Throw away packet if error indicator
-	if p.Header.TransportErrorIndicator {
-		return
-	}
-
 	// Throw away packets that don't have a payload until we figure out what we're going to do with them
 	// TODO figure out what we're going to do with them :D
 	if !p.Header.HasPayload {


### PR DESCRIPTION
I wasn't sure why TEI marked packets were being dropped altogether.

It makes more sense to me to return the data in-tact to the caller and let them decide what to do. Chances are the audio/video can be decoded even if there are errors, because many codecs has some sort of error concealment built-in. In fact, its likely easier for the decoder to function if all the data is there and some of it is corrupted, vs chunks of data randomly missing in the middle.

wdyt?