### PR TITLE
Demuxer: emit an error in case of unknown data packets and EOF

### DIFF
--- a/demuxer.go
+++ b/demuxer.go
@@ -119,7 +119,8 @@ func (dmx *Demuxer) NextData() (d *DemuxerData, err error) {
 					}
 
 					// Parse data
-					if ds, err = parseData(ps, dmx.optPacketsParser, dmx.programMap); err != nil {
+					var errParseData error
+					if ds, errParseData = parseData(ps, dmx.optPacketsParser, dmx.programMap); errParseData != nil {
 						// We need to silence this error as there may be some incomplete data here
 						// We still want to try to parse all packets, in case final data is complete
 						continue
@@ -127,6 +128,7 @@ func (dmx *Demuxer) NextData() (d *DemuxerData, err error) {
 
 					// Update data
 					if d = dmx.updateData(ds); d != nil {
+						err = nil
 						return
 					}
 				}


### PR DESCRIPTION
Fixes #26 

Fixes  https://github.com/aler9/rtsp-simple-server/issues/558

At the moment, demuxer's `NextData()` returns `(nil, nil)` when the stream is finished (EOF), there are TS packets in the queue but they're unknown data packets (not PSI or PES).

This is due to the fact that `err` is overridden by a call to `parseData()`, that sets it to `nil` unless there's a parse error.

In my opinion, the function:

* should return  `(nil, ErrNoMorePackets)` in case there are TS packets with payload in the queue but they can't be parsed.
* should return `(data, nil)` in case the TS packets in the queue are known data packets

This patch fixes the issue.
