### PR TITLE
avoid adding stuffing in without_header test

### DIFF
--- a/data_pes_test.go
+++ b/data_pes_test.go
@@ -242,9 +242,6 @@ var pesTestCases = []pesTestCase{
 		},
 		func(w *astikit.BitsWriter, withStuffing bool, withCRC bool) {
 			w.Write([]byte("data")) // Data
-			if withStuffing {
-				w.Write([]byte("stuff")) // Stuffing
-			}
 		},
 		&PESData{
 			Data: []byte("data"),


### PR DESCRIPTION
I noticed the without_header test had a mismatch in the header Packet length vs the number of bytes actually in the pes data.

At first I tried to make them match, but that caused a ton of test failures:

```diff
--- a/data_pes_test.go
+++ b/data_pes_test.go
@@ -233,9 +233,13 @@ var pesTestCases = []pesTestCase{
 	{
 		"without_header",
 		func(w *astikit.BitsWriter, withStuffing bool, withCRC bool) {
+			len := 4
+			if withStuffing {
+				len += 5
+			}
 			w.Write("000000000000000000000001")   // Prefix
 			w.Write(uint8(StreamIDPaddingStream)) // Stream ID
-			w.Write(uint16(4))                    // Packet length
+			w.Write(uint16(len))                  // Packet length
 		},
 		func(w *astikit.BitsWriter, withStuffing bool, withCRC bool) {
 			// do nothing here
```

In the end it was simpler to remove the stuffing from the without_header test case.

The tests pass either way, but this discrepancy caused failures in some new tests I'm trying to add.