### PR TITLE
Handle truncated PES packets

### DIFF
--- a/data_pes.go
+++ b/data_pes.go
@@ -129,6 +129,12 @@ func parsePESData(i *astikit.BytesIterator) (d *PESData, err error) {
 		return
 	}
 
+	var dataAvailable = i.Len() - dataStart
+	if int(d.Header.PacketLength) > dataAvailable {
+		dataEnd = dataAvailable + dataStart
+		d.Header.PacketLength = uint16(dataAvailable)
+	}
+
 	// Seek to data
 	i.Seek(dataStart)
 


### PR DESCRIPTION
Simple fix for #35 

Unfortunately this is breaking some tests which are creating and operating on malformed packets.

```
--- FAIL: TestParsePESData (0.00s)
    --- FAIL: TestParsePESData/with_header (0.00s)
        data_pes_test.go:407:
            	Error Trace:	data_pes_test.go:407
            	Error:      	Not equal:
            	            	expected: &astits.PESData{Data:[]uint8{0x64, 0x61, 0x74, 0x61}, Header:(*astits.PESHeader)(0x1381690)}
            	            	actual  : &astits.PESData{Data:[]uint8{0x64, 0x61, 0x74, 0x61, 0x73, 0x74, 0x75, 0x66, 0x66}, Header:(*astits.PESHeader)(0xc0000534a0)}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,4 +1,4 @@
            	            	 (*astits.PESData)({
            	            	- Data: ([]uint8) (len=4) {
            	            	-  00000000  64 61 74 61                                       |data|
            	            	+ Data: ([]uint8) (len=9) {
            	            	+  00000000  64 61 74 61 73 74 75 66  66                       |datastuff|
            	            	  },
            	            	@@ -62,3 +62,3 @@
            	            	   }),
            	            	-  PacketLength: (uint16) 67,
            	            	+  PacketLength: (uint16) 9,
            	            	   StreamID: (uint8) 1
            	Test:       	TestParsePESData/with_header
--- FAIL: TestParseData (0.00s)
    data_test.go:47:
        	Error Trace:	data_test.go:47
        	Error:      	Not equal:
        	            	expected: []*astits.DemuxerData{(*astits.DemuxerData)(0xc000073770)}
        	            	actual  : []*astits.DemuxerData{(*astits.DemuxerData)(0xc000073720)}

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -24,4 +24,4 @@
        	            	   PES: (*astits.PESData)({
        	            	-   Data: ([]uint8) (len=4) {
        	            	-    00000000  64 61 74 61                                       |data|
        	            	+   Data: ([]uint8) (len=9) {
        	            	+    00000000  64 61 74 61 73 74 75 66  66                       |datastuff|
        	            	    },
        	            	@@ -85,3 +85,3 @@
        	            	     }),
        	            	-    PacketLength: (uint16) 67,
        	            	+    PacketLength: (uint16) 9,
        	            	     StreamID: (uint8) 1
        	Test:       	TestParseData
FAIL
FAIL	github.com/asticode/go-astits	0.008s
FAIL
```

Specifically, the `with_header` PES test advertises a packet length of 67 even though it only has 9 bytes of data:

https://github.com/asticode/go-astits/blob/473f66c0d7ff8e35f155c629471b214018b61fe0/data_pes_test.go#L258-L265

https://github.com/asticode/go-astits/blob/473f66c0d7ff8e35f155c629471b214018b61fe0/data_pes_test.go#L329-L332

I tried to fix these tests but they make a lot of assumptions and reuse fixtures like `pesWithHeaderBytes()` which creates quite the rabbit hole.