### PR TITLE
improve performance of parseDVBTime

### DIFF
--- a/dvb.go
+++ b/dvb.go
@@ -31,9 +31,9 @@ func parseDVBTime(i *astikit.BytesIterator) (t time.Time, err error) {
 	if mt == 14 || mt == 15 {
 		k = 1
 	}
-	var y = yt + k
+	var y = 1900 + yt + k
 	var m = mt - 1 - k*12
-	t, _ = time.Parse("06-01-02", fmt.Sprintf("%d-%d-%d", y, m, d))
+	t = time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.UTC)
 
 	// Time
 	var s time.Duration

--- a/dvb_test.go
+++ b/dvb_test.go
@@ -62,3 +62,9 @@ func TestWriteDVBDurationSeconds(t *testing.T) {
 	assert.Equal(t, n, buf.Len())
 	assert.Equal(t, dvbDurationSecondsBytes, buf.Bytes())
 }
+
+func BenchmarkDVBTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseDVBTime(astikit.NewBytesIterator(dvbTimeBytes))
+	}
+}


### PR DESCRIPTION
Using time.Date() instead of time.Parse() and fmt.Sprintf() increases performance by 600%. A benchmark has been added in order to prove it.

Before:

```
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkDVBTime
BenchmarkDVBTime-12      3604104               334.9 ns/op
PASS
ok      github.com/asticode/go-astits   1.554s
```

After:

```
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkDVBTime
BenchmarkDVBTime-12     22340049                53.35 ns/op
PASS
ok      github.com/asticode/go-astits   1.256s
```