### PR TITLE
Fix descriptor panic

### DIFF
--- a/descriptor.go
+++ b/descriptor.go
@@ -2002,6 +2002,10 @@ func calcDescriptorLength(d *Descriptor) uint8 {
 		return calcDescriptorUserDefinedLength(d.UserDefined)
 	}
 
+	if d.Length == 0 {
+		return 0
+	}
+
 	switch d.Tag {
 	case DescriptorTagAC3:
 		return calcDescriptorAC3Length(d.AC3)
@@ -2067,6 +2071,10 @@ func writeDescriptor(w *astikit.BitsWriter, d *Descriptor) (int, error) {
 	}
 
 	written := int(length) + 2
+
+	if d.Length == 0 {
+		return written, nil
+	}
 
 	if d.Tag >= 0x80 && d.Tag <= 0xfe {
 		return written, writeDescriptorUserDefined(w, d.UserDefined)

--- a/testdata/fuzz/FuzzDescriptor/6ae8bb726335d15a
+++ b/testdata/fuzz/FuzzDescriptor/6ae8bb726335d15a
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0\x060\x02000\x00")

--- a/testdata/fuzz/FuzzDescriptor/c18ae01ae2349b75
+++ b/testdata/fuzz/FuzzDescriptor/c18ae01ae2349b75
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0\x060\x0200X\x00")


### PR DESCRIPTION
We've seen this panic in the wild and were able to reproduce it with fuzzing.

```
$ go test -fuzz FuzzDescriptor
fuzz: elapsed: 0s, gathering baseline coverage: 0/379 completed
failure while testing seed corpus entry: FuzzDescriptor/6ae8bb726335d15a
fuzz: elapsed: 0s, gathering baseline coverage: 0/379 completed
--- FAIL: FuzzDescriptor (0.04s)
    --- FAIL: FuzzDescriptor (0.00s)
        testing.go:1485: panic: runtime error: invalid memory address or nil pointer dereference
            goroutine 25 [running]:
            runtime/debug.Stack()
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/debug/stack.go:24 +0xbc
            testing.tRunner.func1()
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1485 +0x264
            panic({0x1012351e0, 0x1013fc680})
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/panic.go:884 +0x204
            github.com/asticode/go-astits.calcDescriptorUnknownLength(...)
            	/Users/eric/src/go-astits/descriptor.go:1989
            github.com/asticode/go-astits.calcDescriptorLength(0x140000e00f0)
            	/Users/eric/src/go-astits/descriptor.go:2055 +0x111c
            github.com/asticode/go-astits.calcDescriptorsLength(...)
            	/Users/eric/src/go-astits/descriptor.go:2131
            github.com/asticode/go-astits.writeDescriptorsWithLength(0x1400011d690?, {0x1400008c3e0?, 0x2?, 0x2?})
            	/Users/eric/src/go-astits/descriptor.go:2151 +0x6c
            github.com/asticode/go-astits.FuzzDescriptor.func1(0x1400011d718?, {0x1400009a3e8?, 0x0?, 0x0?})
            	/Users/eric/src/go-astits/descriptor_test.go:731 +0x1f8
            reflect.Value.call({0x10122b400?, 0x101276e58?, 0x1400006ee38?}, {0x1011988e5, 0x4}, {0x140000985a0, 0x2, 0x0?})
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/reflect/value.go:586 +0x87c
            reflect.Value.Call({0x10122b400?, 0x101276e58?, 0x14000092000?}, {0x140000985a0?, 0x101276420?, 0x101395580?})
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/reflect/value.go:370 +0x90
            testing.(*F).Fuzz.func1.1(0x140000103c0?)
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/fuzz.go:335 +0x360
            testing.tRunner(0x14000082b60, 0x140000aa3f0)
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x10c
            created by testing.(*F).Fuzz.func1
            	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/fuzz.go:322 +0x4c4
            
    
FAIL
exit status 1
FAIL	github.com/asticode/go-astits	0.521s
```