### PR TITLE
Solve the the issue of non-DVB transport stream(TS) which using the PID, 0x10~0x1F, as the PIDs of the video/audio streams of program

### DIFF
--- a/data.go
+++ b/data.go
@@ -36,7 +36,7 @@ type MuxerData struct {
 }
 
 // parseData parses a payload spanning over multiple packets and returns a set of data
-func parseData(ps []*Packet, prs PacketsParser, pm *programMap) (ds []*DemuxerData, err error) {
+func parseData(ps []*Packet, prs PacketsParser, pm *programMap, esm *elementaryStreamMap) (ds []*DemuxerData, err error) {
 	// Use custom parser first
 	if prs != nil {
 		var skip bool
@@ -80,7 +80,7 @@ func parseData(ps []*Packet, prs PacketsParser, pm *programMap) (ds []*DemuxerDa
 	if pid == PIDCAT {
 		// Information in a CAT payload is private and dependent on the CA system. Use the PacketsParser
 		// to parse this type of payload
-	} else if isPSIPayload(pid, pm) {
+	} else if isPSIPayload(pid, pm, esm) {
 		// Parse PSI data
 		var psiData *PSIData
 		if psiData, err = parsePSIData(i); err != nil {
@@ -111,11 +111,11 @@ func parseData(ps []*Packet, prs PacketsParser, pm *programMap) (ds []*DemuxerDa
 }
 
 // isPSIPayload checks whether the payload is a PSI one
-func isPSIPayload(pid uint16, pm *programMap) bool {
+func isPSIPayload(pid uint16, pm *programMap, esm *elementaryStreamMap) bool {
 	return pid == PIDPAT || // PAT
 		pm.existsUnlocked(pid) || // PMT
 		(((pid >= 0x10 && pid <= 0x14) || (pid >= 0x1e && pid <= 0x1f)) && //DVB
-			!pm.existsLocked(pid)) // for non-DVB
+			!esm.existsLocked(pid)) // for non-DVB
 }
 
 // isPESPayload checks whether the payload is a PES one

--- a/data.go
+++ b/data.go
@@ -3,6 +3,7 @@ package astits
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/asticode/go-astikit"
 )
 
@@ -113,7 +114,8 @@ func parseData(ps []*Packet, prs PacketsParser, pm *programMap) (ds []*DemuxerDa
 func isPSIPayload(pid uint16, pm *programMap) bool {
 	return pid == PIDPAT || // PAT
 		pm.existsUnlocked(pid) || // PMT
-		((pid >= 0x10 && pid <= 0x14) || (pid >= 0x1e && pid <= 0x1f)) //DVB
+		(((pid >= 0x10 && pid <= 0x14) || (pid >= 0x1e && pid <= 0x1f)) && //DVB
+			!pm.existsLocked(pid)) // for non-DVB
 }
 
 // isPESPayload checks whether the payload is a PES one

--- a/data_test.go
+++ b/data_test.go
@@ -11,6 +11,7 @@ import (
 func TestParseData(t *testing.T) {
 	// Init
 	pm := newProgramMap()
+	esm := newElementaryStreamMap()
 	ps := []*Packet{}
 
 	// Custom parser
@@ -20,13 +21,13 @@ func TestParseData(t *testing.T) {
 		skip = true
 		return
 	}
-	ds, err := parseData(ps, c, pm)
+	ds, err := parseData(ps, c, pm, esm)
 	assert.NoError(t, err)
 	assert.Equal(t, cds, ds)
 
 	// Do nothing for CAT
 	ps = []*Packet{{Header: PacketHeader{PID: PIDCAT}}}
-	ds, err = parseData(ps, nil, pm)
+	ds, err = parseData(ps, nil, pm, esm)
 	assert.NoError(t, err)
 	assert.Empty(t, ds)
 
@@ -42,7 +43,7 @@ func TestParseData(t *testing.T) {
 			Payload: p[33:],
 		},
 	}
-	ds, err = parseData(ps, nil, pm)
+	ds, err = parseData(ps, nil, pm, esm)
 	assert.NoError(t, err)
 	assert.Equal(t, []*DemuxerData{
 		{
@@ -64,7 +65,7 @@ func TestParseData(t *testing.T) {
 			Payload: p[33:],
 		},
 	}
-	ds, err = parseData(ps, nil, pm)
+	ds, err = parseData(ps, nil, pm, esm)
 	assert.NoError(t, err)
 	assert.Equal(t, psi.toData(
 		&Packet{Header: ps[0].Header, AdaptationField: ps[0].AdaptationField},
@@ -74,15 +75,16 @@ func TestParseData(t *testing.T) {
 
 func TestIsPSIPayload(t *testing.T) {
 	pm := newProgramMap()
+	esm := newElementaryStreamMap()
 	var pids []int
 	for i := 0; i <= 255; i++ {
-		if isPSIPayload(uint16(i), pm) {
+		if isPSIPayload(uint16(i), pm, esm) {
 			pids = append(pids, i)
 		}
 	}
 	assert.Equal(t, []int{0, 16, 17, 18, 19, 20, 30, 31}, pids)
 	pm.setUnlocked(uint16(1), uint16(0))
-	assert.True(t, isPSIPayload(uint16(1), pm))
+	assert.True(t, isPSIPayload(uint16(1), pm, esm))
 }
 
 func TestIsPESPayload(t *testing.T) {

--- a/demuxer.go
+++ b/demuxer.go
@@ -199,6 +199,11 @@ func (dmx *Demuxer) updateData(ds []*DemuxerData) (d *DemuxerData) {
 					}
 				}
 			}
+			if v.PMT != nil {
+				for _, es := range v.PMT.ElementaryStreams {
+					dmx.programMap.setLocked(es.ElementaryPID, v.PMT.ProgramNumber)
+				}
+			}
 		}
 	}
 	return

--- a/demuxer.go
+++ b/demuxer.go
@@ -34,6 +34,7 @@ type Demuxer struct {
 	packetBuffer *packetBuffer
 	packetPool   *packetPool
 	programMap   *programMap
+	streamMap    *elementaryStreamMap
 	r            io.Reader
 }
 
@@ -52,6 +53,7 @@ func NewDemuxer(ctx context.Context, r io.Reader, opts ...func(*Demuxer)) (d *De
 		ctx:        ctx,
 		l:          astikit.AdaptStdLogger(nil),
 		programMap: newProgramMap(),
+		streamMap:  newElementaryStreamMap(),
 		r:          r,
 	}
 	d.packetPool = newPacketPool(d.programMap)
@@ -145,7 +147,7 @@ func (dmx *Demuxer) NextData() (d *DemuxerData, err error) {
 
 					// Parse data
 					var errParseData error
-					if ds, errParseData = parseData(ps, dmx.optPacketsParser, dmx.programMap); errParseData != nil {
+					if ds, errParseData = parseData(ps, dmx.optPacketsParser, dmx.programMap, dmx.streamMap); errParseData != nil {
 						// Log error as there may be some incomplete data here
 						// We still want to try to parse all packets, in case final data is complete
 						dmx.l.Error(fmt.Errorf("astits: parsing data failed: %w", errParseData))
@@ -170,7 +172,7 @@ func (dmx *Demuxer) NextData() (d *DemuxerData, err error) {
 		}
 
 		// Parse data
-		if ds, err = parseData(ps, dmx.optPacketsParser, dmx.programMap); err != nil {
+		if ds, err = parseData(ps, dmx.optPacketsParser, dmx.programMap, dmx.streamMap); err != nil {
 			err = fmt.Errorf("astits: building new data failed: %w", err)
 			return
 		}
@@ -201,7 +203,7 @@ func (dmx *Demuxer) updateData(ds []*DemuxerData) (d *DemuxerData) {
 			}
 			if v.PMT != nil {
 				for _, es := range v.PMT.ElementaryStreams {
-					dmx.programMap.setLocked(es.ElementaryPID, v.PMT.ProgramNumber)
+					dmx.streamMap.setLocked(es.ElementaryPID, v.PMT.ProgramNumber)
 				}
 			}
 		}

--- a/program_map.go
+++ b/program_map.go
@@ -4,26 +4,13 @@ package astits
 type programMap struct {
 	// We use map[uint32] instead map[uint16] as go runtime provide optimized hash functions for (u)int32/64 keys
 	p map[uint32]uint16 // map[ProgramMapID]ProgramNumber
-	s map[uint32]uint16 // map[StreamID]ProgramNumber
 }
 
 // newProgramMap creates a new program ids map
 func newProgramMap() *programMap {
 	return &programMap{
 		p: make(map[uint32]uint16),
-		s: make(map[uint32]uint16),
 	}
-}
-
-// setLocked sets a new stream id to the program
-func (m programMap) setLocked(pid, number uint16) {
-	m.s[uint32(pid)] = number
-}
-
-// existsLocked checks whether the stream with this pid exists
-func (m programMap) existsLocked(pid uint16) (ok bool) {
-	_, ok = m.s[uint32(pid)]
-	return
 }
 
 // existsUnlocked checks whether the program with this pid exists

--- a/program_map.go
+++ b/program_map.go
@@ -4,13 +4,26 @@ package astits
 type programMap struct {
 	// We use map[uint32] instead map[uint16] as go runtime provide optimized hash functions for (u)int32/64 keys
 	p map[uint32]uint16 // map[ProgramMapID]ProgramNumber
+	s map[uint32]uint16 // map[StreamID]ProgramNumber
 }
 
 // newProgramMap creates a new program ids map
 func newProgramMap() *programMap {
 	return &programMap{
 		p: make(map[uint32]uint16),
+		s: make(map[uint32]uint16),
 	}
+}
+
+// setLocked sets a new stream id to the program
+func (m programMap) setLocked(pid, number uint16) {
+	m.s[uint32(pid)] = number
+}
+
+// existsLocked checks whether the stream with this pid exists
+func (m programMap) existsLocked(pid uint16) (ok bool) {
+	_, ok = m.s[uint32(pid)]
+	return
 }
 
 // existsUnlocked checks whether the program with this pid exists

--- a/stream_map.go
+++ b/stream_map.go
@@ -1,0 +1,29 @@
+package astits
+
+// elementaryStreamMap represents an elementary stream ids map
+type elementaryStreamMap struct {
+	// We use map[uint32] instead map[uint16] as go runtime provide optimized hash functions for (u)int32/64 keys
+	es map[uint32]uint16 // map[StreamID]ProgramNumber
+}
+
+// newElementaryStreamMap creates a new elementary stream ids map
+func newElementaryStreamMap() *elementaryStreamMap {
+	return &elementaryStreamMap{
+		es: make(map[uint32]uint16),
+	}
+}
+
+// setLocked sets a new stream id to the elementary stream
+func (m elementaryStreamMap) setLocked(pid, number uint16) {
+	m.es[uint32(pid)] = number
+}
+
+// existsLocked checks whether the stream with this pid exists
+func (m elementaryStreamMap) existsLocked(pid uint16) (ok bool) {
+	_, ok = m.es[uint32(pid)]
+	return
+}
+
+func (m elementaryStreamMap) unsetLocked(pid uint16) {
+	delete(m.es, uint32(pid))
+}

--- a/stream_map_test.go
+++ b/stream_map_test.go
@@ -1,0 +1,16 @@
+package astits
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElementaryStreamMap(t *testing.T) {
+	esm := newElementaryStreamMap()
+	assert.False(t, esm.existsLocked(0x16))
+	esm.setLocked(0x16, 1)
+	assert.True(t, esm.existsLocked(0x16))
+	esm.unsetLocked(0x16)
+	assert.False(t, esm.existsLocked(0x16))
+}


### PR DESCRIPTION
###  Scenario

We got the sample transport stream from IPTV source, which using the PID 0x10 as the program PID, 0x11 as the video stream PID, and 0x12 as the audio stream PID. The transport stream would cause the PSI checksum error, while we tried to use the demux to get **NextData()** of the stream.

### ISO Standard

According to the **Table 2-3 -- PID table** of the standard ISO/IEC 13818-1:2007, the PID range 0x0010~0x1FFE may be assigned as network PID, program map PID, elementary_PID, or for other purposes.

![table2-3](https://github.com/asticode/go-astits/assets/45262931/8e18c620-ae04-408e-98df-8aa9c372a596)

### Changes

1. Use existed struct **programMap** to setup the locks of the PIDs which used in the program already
2. While demux **parseData()**, use the locks to avoid the used PIDs of elementary streams to be identified as PSI table.
