### PR TITLE
Add an ability to detect CRC32 mismatch by a checking a specific error

### DIFF
--- a/data_psi.go
+++ b/data_psi.go
@@ -1,6 +1,7 @@
 package astits
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/asticode/go-astikit"
@@ -45,6 +46,8 @@ const (
 	PSITableIDNITVariant1 PSITableID = 0x40
 	PSITableIDNITVariant2 PSITableID = 0x41
 )
+
+var ErrCRC32Mismatch = errors.New("astits: CRC32 mismatch")
 
 // PSIData represents a PSI data
 // https://en.wikipedia.org/wiki/Program-specific_information
@@ -175,7 +178,7 @@ func parsePSISection(i *astikit.BytesIterator) (s *PSISection, stop bool, err er
 
 			// Check CRC32
 			if crc32 != s.CRC32 {
-				err = fmt.Errorf("astits: Table CRC32 %x != computed CRC32 %x", s.CRC32, crc32)
+				err = errors.Join(ErrCRC32Mismatch, fmt.Errorf("astits: Table CRC32 %x != computed CRC32 %x", s.CRC32, crc32))
 				return
 			}
 		}

--- a/data_psi_test.go
+++ b/data_psi_test.go
@@ -2,6 +2,7 @@ package astits
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/asticode/go-astikit"
@@ -168,7 +169,8 @@ func TestParsePSIData(t *testing.T) {
 	w.Write(totBytes())     // TOT data
 	w.Write(uint32(32))     // TOT CRC32
 	_, err := parsePSIData(astikit.NewBytesIterator(buf.Bytes()))
-	assert.EqualError(t, err, "astits: parsing PSI table failed: astits: Table CRC32 20 != computed CRC32 6969b13")
+	assert.True(t, errors.Is(err, ErrCRC32Mismatch))
+	assert.Equal(t, "astits: parsing PSI table failed: astits: CRC32 mismatch\nastits: Table CRC32 20 != computed CRC32 6969b13", err.Error())
 
 	// Valid
 	d, err := parsePSIData(astikit.NewBytesIterator(psiBytes()))

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/asticode/go-astits
 
-go 1.13
+go 1.20
 
 require (
 	github.com/asticode/go-astikit v0.30.0
 	github.com/pkg/profile v1.4.0
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
Sometimes, when you are performing an AES128 decryption with the wrong parameters, it corrupts a PAT, and it would be helpful to detect such errors by checking ademuxer errors on a specific type:  ErrCRC32Mismatch